### PR TITLE
fixed compile error about server log in g++

### DIFF
--- a/apps/server/log.hpp
+++ b/apps/server/log.hpp
@@ -26,21 +26,11 @@ public:
     /// <param name="message">出力されるメッセージ</param>
     static void Trace(std::string_view message);
 
-    static void Trace(std::ostringstream const& message)
-    {
-        Trace(message.str());
-    }
-
     /// <summary>
     /// デバッグ用のログ．主にサーバーの状況を表示する．
     /// </summary>
     /// <param name="message">出力されるメッセージ</param>
     static void Debug(std::string_view message);
-
-    static void Debug(std::ostringstream const& message)
-    {
-        Debug(message.str());
-    }
 
     /// <summary>
     /// GUIによるログ再生ではこのタイプのログを参照する．
@@ -48,32 +38,17 @@ public:
     /// <param name="message">出力されるメッセージ</param>
     static void Info(std::string_view message);
 
-    static void Info(std::ostringstream const& message)
-    {
-        Info(message.str());
-    }
-
     /// <summary>
     /// サーバーを終了する程では無い，異常な動作を検出した場合に使う．
     /// </summary>
     /// <param name="message">出力されるメッセージ</param>
     static void Warn(std::string_view message);
 
-    static void Warn(std::ostringstream const& message)
-    {
-        Warn(message.str());
-    }
-
     /// <summary>
     /// 通信などにエラーが発生した場合用いる．このメッセージを出したらサーバーは速やかに終了する．
     /// </summary>
     /// <param name="message">出力されるメッセージ</param>
     static void Error(std::string_view message);
-
-    static void Error(std::ostringstream const& message)
-    {
-        Error(message.str());
-    }
 
 private:
     std::ofstream file_;

--- a/apps/server/main.cpp
+++ b/apps/server/main.cpp
@@ -10,6 +10,7 @@ using boost::asio::ip::tcp;
 using namespace digital_curling;
 using digital_curling::server::Log;
 using nlohmann::json;
+using Buf = std::ostringstream;
 
 int main(int argc, char* const argv[])
 {
@@ -40,7 +41,7 @@ int main(int argc, char* const argv[])
         std::ofstream file;
         for (int count = 0; !file.is_open(); ++count) {
             // ゲームIDを作成
-            std::ostringstream game_id_buf;
+            Buf game_id_buf;
             game_id_buf << date_time << '_' << std::setfill('0') << std::right << std::setw(3) << count;
             server_setting.game_id = game_id_buf.str();
 
@@ -74,8 +75,8 @@ int main(int argc, char* const argv[])
     }
 
     try {
-        Log::Debug(std::ostringstream() << "log file path: " << std::filesystem::absolute(file_name));
-        Log::Debug(std::ostringstream() << "game id: " << server_setting.game_id);
+        Log::Debug((Buf() << "log file path: " << std::filesystem::absolute(file_name)).str());
+        Log::Debug((Buf() << "game id: " << server_setting.game_id).str());
 
         // TODO 起動設定ファイルを読み込む．
         std::ifstream config_file(argv[1]);
@@ -109,10 +110,10 @@ int main(int argc, char* const argv[])
         boost::asio::io_context io_context;
 
         tcp::endpoint listen_endpoint0(tcp::v4(), port0);
-        Log::Debug(std::ostringstream() << "port 0: " << listen_endpoint0.port());
+        Log::Debug((Buf() << "port 0: " << listen_endpoint0.port()).str());
 
         tcp::endpoint listen_endpoint1(tcp::v4(), port1);
-        Log::Debug(std::ostringstream() << "port 1: " << listen_endpoint1.port());
+        Log::Debug((Buf() << "port 1: " << listen_endpoint1.port()).str());
 
         server::Server s(io_context, listen_endpoint0, listen_endpoint1, server_setting, game_setting, *simulator_setting);
 

--- a/apps/server/server.cpp
+++ b/apps/server/server.cpp
@@ -60,11 +60,11 @@ void Channel::Leave(size_t client_id)
     assert(client_id < clients_.size());
     clients_[client_id].session.reset();
 
-    Log::Debug(Buf() << "Client " << client_id << " was left from channel.");
+    Log::Debug((Buf() << "Client " << client_id << " was left from channel.").str());
 
     if (clients_[client_id].state != Client::State::kGameOver) {
         // 正常なタイミングでの終了ではない
-        Log::Error(Buf() << "Client " << client_id << " was left from channel at inappropriate time.");
+        Log::Error((Buf() << "Client " << client_id << " was left from channel at inappropriate time.").str());
         StopServer();
     }
     // 正常なタイミングの終了の場合，これ以上することは無い．
@@ -74,7 +74,7 @@ void Channel::StartContact(size_t client_id)
 {
     assert(clients_.at(client_id).state == Client::State::kBeforeContact);
 
-    Log::Debug(Buf() << "Start contact with client " << client_id);
+    Log::Debug((Buf() << "Start contact with client " << client_id).str());
 
     clients_.at(client_id).state = Client::State::kVersionCheck;
 
@@ -214,7 +214,7 @@ void Channel::OnRead(size_t client_id, std::string && input_message, std::chrono
 
             case Client::State::kGameOver: {
                 // nothing to do
-                Log::Warn(Buf() << "client " << client_id << "'s message was ignored.");
+                Log::Warn((Buf() << "client " << client_id << "'s message was ignored.").str());
                 break;
             }
 
@@ -303,7 +303,7 @@ void Channel::OnInputTimeout(size_t client_id)
 {
     switch (clients_.at(client_id).state) {
         case Client::State::kMyTurn: {
-            Log::Debug(Buf() << "Client " << client_id << " timed out.");
+            Log::Debug((Buf() << "Client " << client_id << " timed out.").str());
             // 制限時間切れにより負け．
             clients_[client_id].remaining_time = std::chrono::seconds(0);
             normal_game::Move move = normal_game::move::TimeLimit();
@@ -314,7 +314,7 @@ void Channel::OnInputTimeout(size_t client_id)
         }
 
         default:
-            Log::Error(Buf() << "Client " << client_id << " timed out at an inappropriate time.");
+            Log::Error((Buf() << "Client " << client_id << " timed out at an inappropriate time.").str());
             StopServer();
             break;
     }
@@ -336,7 +336,7 @@ void Channel::Update(normal_game::Move & move)
 {
     auto current_client = ToClientId(game_state_.GetCurrentTeam());
     if (clients_[current_client].remaining_time.count() <= 0) {
-        Log::Debug(Buf() << "Client " << current_client << " lost the game because of the time limit.");
+        Log::Debug((Buf() << "Client " << current_client << " lost the game because of the time limit.").str());
         move = normal_game::move::TimeLimit();
     }
 
@@ -447,7 +447,7 @@ void TCPSession::Stop()
     input_deadline_.cancel();
     non_empty_output_queue_.cancel();
 
-    Log::Debug(Buf() << "Client " << client_id_ << "'s session was stopped.");
+    Log::Debug((Buf() << "Client " << client_id_ << "'s session was stopped.").str());
 }
 
 bool TCPSession::IsStopped() const
@@ -467,7 +467,7 @@ void TCPSession::ReadLine()
 
             if (error) {
                 // このエラーはクライアントが正常に接続を解除した際にも呼ばれる
-                Log::Debug(Buf() << "error in client " << client_id_ << " read line. " << error.message());
+                Log::Debug((Buf() << "error in client " << client_id_ << " read line. " << error.message()).str());
                 channel_.Leave(client_id_);
                 Stop();
                 return;
@@ -496,7 +496,7 @@ void TCPSession::ReadLine()
                 } else {
                     buf << "(too long (size=" << msg.size() << "))";
                 }
-                Log::Trace(buf);
+                Log::Trace(buf.str());
             }
 
             channel_.OnRead(client_id_, std::move(msg), elapsed_from_output);
@@ -535,7 +535,7 @@ void TCPSession::WriteLine()
 
             if (error) {
                 // このエラーはクライアントが正常に接続を解除した際にも呼ばれる
-                Log::Error(Buf() << "error in client " << client_id_ << " write line. " << error.message());
+                Log::Error((Buf() << "error in client " << client_id_ << " write line. " << error.message()).str());
                 channel_.Leave(client_id_);
                 Stop();
                 return;
@@ -553,7 +553,7 @@ void TCPSession::WriteLine()
 
             {
                 std::string_view str = std::string_view(message.message).substr(0, message.message.size() - 1);
-                Log::Trace(Buf() << "[out] client=" << client_id_ << ", message=" << str);
+                Log::Trace((Buf() << "[out] client=" << client_id_ << ", message=" << str).str());
             }
 
             output_queue_.pop_front();


### PR DESCRIPTION
Visual Studioによって拡張されたC++の機能を使ったためにg++でコンパイルエラーが発生してしまった件を修正．

## エラー発生の原因

`std::ostringstream` の `operator <<` の戻り値はVisual Studioでは `std::ostringstream&` であるが，g++では `std::basic_ostream<char>&` であった．このVisual Studioの挙動は独自拡張の模様です．